### PR TITLE
Increase timeout to 60s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /images
 /.vagrant
+.DS_*

--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/hostapd.conf
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/hostapd.conf
@@ -1,4 +1,4 @@
-country_code=IN
+country_code=ES
 
 ctrl_interface=/var/run/hostapd
 interface=wlan0

--- a/aa_wireless_dongle/package/aawg/src/proxyHandler.cpp
+++ b/aa_wireless_dongle/package/aawg/src/proxyHandler.cpp
@@ -169,7 +169,7 @@ void AAWProxy::handleClient(int server_sock) {
     BluetoothHandler::instance().stopConnectWithRetry();
 
     if (Config::instance()->getConnectionStrategy() != ConnectionStrategy::USB_FIRST) {
-        if (!UsbManager::instance().enableDefaultAndWaitForAccessory(std::chrono::seconds(30))) {
+        if (!UsbManager::instance().enableDefaultAndWaitForAccessory(std::chrono::seconds(60))) {
             return;
         }
     }


### PR DESCRIPTION
Sometimes I don't need to start Android Auto, so I don't open the application in the car (Peugeot 5008, year 2018). The phone is connected properly but since the timeout for the connection is 30 seconds, I receive a notification in my phone remembering me Android Auto is available.
This PR is to check if:
- The change works and I get the notification each minute instead of 60 seconds
- If I can start the application in my car in the second 50.
